### PR TITLE
Test with postfix (gencall convention) off and on.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
         "eslint": "eslint logo",
         "pkut": "node tools/pklgo.js unittests > generated/unittests.js",
         "pkdemo": "node tools/pklgo.js demo > generated/demo.js",
-        "build": "npm run eslint && npm run pkdemo",
-        "test": "npm run pkut && node logo/logo test",
+        "build": "npm run eslint && npm run pkdemo && npm run pkut",
+        "test": "node logo/logo test && node logo/logo test on:postfix",
         "server": "http-server",
         "predeploy": "rm -rf unittests && rm -rf demo && rm -rf node_modules"
     }


### PR DESCRIPTION
The posfix gencall convention is used in cases when evaluation of parameter cannot be transpiled into a JS expression. For example when the evaluation must be wrapped in a try..catch block. The 'postfix' switch being on will force the use of postfix convention. Running unit tests with two passes, with the 'postfix' switch being off and on, will increase the coverage of regression testing to code paths supporting postfix convention.