### PR TITLE
Revamp cmdline args parsing.

### DIFF
--- a/logo/config.js
+++ b/logo/config.js
@@ -17,21 +17,18 @@ $classObj.create = function(sys) {
         trace: true
     };
 
-    config.set = function(configName, val) {
-        sys.assert(configName in configMap, "Unknown configMap:" + configName);
-        sys.assert(typeof val == typeof configMap[configName], "Expect type:" + typeof configMap[configName] + " but got type:" + typeof val + " on configMap:" + configName);
-        configMap[configName] = val;
-    };
+    function set(key, val) {
+        sys.assert(key in configMap, "Unknown configMap:" + key);
+        sys.assert(typeof val == typeof configMap[key], "Expect type:" + typeof configMap[key] + " but got type:" + typeof val + " on configMap:" + key);
+        configMap[key] = val;
+    }
+    config.set = set;
 
-    config.get = function(configName) {
-        sys.assert(configName in configMap, "Unknown configMap:" + configName);
-        return configMap[configName];
-    };
-
-    config.setConfigs = function(configNames, val) {
-        configNames.forEach(configName =>
-            config.set(configName, val));
-    };
+    function get(key) {
+        sys.assert(key in configMap, "Unknown configMap:" + key);
+        return configMap[key];
+    }
+    config.get = get;
 
     return config;
 };

--- a/logo/logo.js
+++ b/logo/logo.js
@@ -21,6 +21,27 @@ const sys = classFromJs("./sys.js").create(isNodeJsEnvFlag, util);
 const Logo = {};
 const testRunner = classFromJs("./testrunner.js").create(Logo, sys);
 
+Logo.mode = {
+    CODEGEN: "codegen",
+    CONSOLE: "console",
+    EXEC: "exec",
+    EXECJS: "execjs",
+    EXECL: "execl",
+    HELP: "help",
+    PARSE: "parse",
+    RUN: "run",
+    RUNL: "runl",
+    TEST: "test"
+};
+
+Logo.modeName = ((mode) => {
+    const modeName = {};
+    Object.keys(mode).forEach(key => {
+        modeName[mode[key]] = key;
+    });
+    return modeName;
+})(Logo.mode);
+
 Logo.getUnitTests = (() => {
     let unitTests = undefined;
     return function() {
@@ -32,7 +53,7 @@ Logo.getUnitTests = (() => {
     };
 })();
 
-Logo.create = function(ext) {
+Logo.create = function(ext, config=undefined) {
 
     const logo = {};
 
@@ -51,23 +72,15 @@ Logo.create = function(ext) {
     logo.parse = classFromJs("./parse.js").create(logo, sys);
     logo.env = classFromJs("./env.js").create(logo, sys, ext);
     logo.logofs = classFromJs("./logofs.js").create(logo, sys);
-    logo.config = classFromJs("./config.js").create(sys);
+    logo.config = (config === undefined) ? classFromJs("./config.js").create(sys) : config;
     logo.trace = classFromJs("./trace.js").create(logo, sys);
 
     logo.env.initLogoEnv();
 
+    logo.mode = Logo.mode.EXEC;
+
     return logo;
 }; // Logo.create
-
-Logo.mode = {
-    PARSE: "parse",
-    RUN: "run",
-    RUNL: "runl",
-    EXEC: "exec",
-    EXECL: "execl",
-    EXECJS: "execjs",
-    CODEGEN: "codegen"
-};
 
 Logo.testRunner = testRunner;
 

--- a/logo/logoInWeb.js
+++ b/logo/logoInWeb.js
@@ -67,7 +67,7 @@ $classObj.create = function logoInWeb(Logo, sys) { // eslint-disable-line no-unu
     }
 
     async function webRunSingleTest(testName, testMethod) {
-        await Logo.testRunner.runSingleTest(Logo.getUnitTests(), testName, testMethod, ext);
+        await Logo.testRunner.runSingleTest(Logo.getUnitTests(), testName, testMethod, logo);
         postMessage([logo.env.getEnvState()]);
     }
 
@@ -75,7 +75,7 @@ $classObj.create = function logoInWeb(Logo, sys) { // eslint-disable-line no-unu
         const webMsgHandler = {
             "test": async () => {
                 postMessage(["busy"]);
-                await Logo.testRunner.runTests(Logo.getUnitTests(), undefined, ext);
+                await Logo.testRunner.runTests(Logo.getUnitTests(), undefined, logo);
                 postMessage(["ready"]);
             },
             "run": async (e) => {

--- a/logo/trace.js
+++ b/logo/trace.js
@@ -22,29 +22,32 @@ $classObj.create = function(logo, sys) {
         "tmp"
     ];
 
-    const Trace = {};
+    const trace = {};
 
     const traceTable = {};
     traceKeys.forEach(v => traceTable[v] = () => {});
 
-    Trace.setTraceOptions = function(keysOn) {
-        const reKeysOn = sys.makeMatchListRegexp(keysOn);
-        traceKeys.filter(v => v.match(reKeysOn))
+    function enableTrace(tagPattern) {
+        const reTags = sys.makeMatchListRegexp(tagPattern);
+        traceKeys.filter(v => v.match(reTags))
             .forEach(v => traceTable[v] = console.error); // eslint-disable-line no-console
-    };
+    }
+    trace.enableTrace = enableTrace;
 
-    Trace.info = function(text, key) {
-        sys.assert(key in traceTable, "Unknown trace key: " + key);
+    function info(text, tag) {
+        sys.assert(tag in traceTable, "Unknown trace tag: " + tag);
         if (logo.config.get("trace")) {
-            traceTable[key](text);
+            traceTable[tag](text);
         }
-    };
+    }
+    trace.info = info;
 
-    Trace.getTraceStream = function(key) {
-        return traceTable[key];
-    };
+    function getTraceStream(tag) {
+        return traceTable[tag];
+    }
+    trace.getTraceStream = getTraceStream;
 
-    return Trace;
+    return trace;
 };
 
 if (typeof exports != "undefined") {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "scripts": {
         "clean": "rm generated/*.js",
         "eslint": "eslint logo",
-        "pkmod": "node tools/pkdir.js mod > generated/mod.js",
-        "pkut": "node tools/pkut.js unittests > generated/unittests.js",
-        "pkdemo": "node tools/pkdir.js demo > generated/demo.js",
+        "pkmod": "node tools/pkdir mod > generated/mod.js",
+        "pkut": "node tools/pkut unittests > generated/unittests.js",
+        "pkdemo": "node tools/pkdir demo > generated/demo.js",
         "build": "npm run eslint && npm run pkdemo && npm run pkut && npm run pkmod",
-        "test": "node logo/logo test && node logo/logo test null on:postfix",
+        "test": "node logo/logo --test && node logo/logo --test --on:postfix",
         "server": "http-server",
         "predeploy": "rm -rf unittests && rm -rf demo && rm -rf node_modules"
     }


### PR DESCRIPTION
```
Usage:
        node logo                            - interactive mode
        node logo <LGO file>                 - compile to JS and execute
        node logo --parse <LGO file>         - parse only
        node logo --codegen <LGO file>       - generate JS code
        node logo --run <LGO file>           - run with interpreter
        node logo --exec <LGO file>          - compile to JS and execute
        node logo --execjs <JS file>         - execute precompiled JS
        node logo --test [<test name>]       - run JavaScript unit test file

        options:[--on,--off,--trace]
        trace:[parse,evx,codegen,lrt,time,draw]
```