### PR TITLE
Implement TIME; clean up double spaces.

### DIFF
--- a/logo/env.js
+++ b/logo/env.js
@@ -44,7 +44,7 @@ $classObj.create = function(logo, sys, ext) {
     env.createParamScope = createParamScope;
 
     let _logoMode = LogoMode.BATCH;
-    let _globalScope, _envState, _runTime,  _userInput, _resolveUserInput;
+    let _globalScope, _envState, _runTime, _userInput, _resolveUserInput;
     let _asyncFunctionCall;
     let _genJs;
     let $primitiveName, $primitiveSrcmap;
@@ -141,7 +141,7 @@ $classObj.create = function(logo, sys, ext) {
     env.extractSlotNum = extractSlotNum;
 
     function getSlotValue(slotNum) {
-        logo.type.ifTrueThenThrow(slotNum > env._curSlot.length,  logo.type.LogoException.INVALID_INPUT, slotNum);
+        logo.type.ifTrueThenThrow(slotNum > env._curSlot.length, logo.type.LogoException.INVALID_INPUT, slotNum);
         return env._curSlot[slotNum - 1];
     }
     env.getSlotValue = getSlotValue;

--- a/logo/lrt.js
+++ b/logo/lrt.js
@@ -546,6 +546,11 @@ $classObj.create = function(logo, sys) {
         return await logo.env.applyInstrList(template, srcmap, unboxedInputList);
     }
 
+    function primitiveTime() {
+        let date = new Date().toString().split(" "); // E.g. [Sat Sep 01 2018 14:53:26 GMT+1400 (LINT)]
+        return logo.type.makeLogoList(date.slice(0, 3).concat(date[4], date[3]));
+    }
+
     function primitiveTimeMilli() {
         return new Date().getTime();
     }
@@ -863,6 +868,8 @@ $classObj.create = function(logo, sys) {
         "readword": primitiveReadword,
 
         "apply": primitiveApply,
+
+        "time": primitiveTime,
 
         "timemilli": primitiveTimeMilli,
 

--- a/logo/parse.js
+++ b/logo/parse.js
@@ -488,7 +488,7 @@ $classObj.create = function(logo, sys) {
                     pushParseStackWithData(Delimiter.getExpectedClosing(c), Delimiter.getLiteralFactory(c));
                 } else if (Delimiter.isClosing(c)) {
                     if (_parseExpecting !== c) {
-                        throw logo.type.LogoException.UNEXPECTED_TOKEN.withParam([c],  makeSrcmap());
+                        throw logo.type.LogoException.UNEXPECTED_TOKEN.withParam([c], makeSrcmap());
                     }
 
                     popParseStackWithData();

--- a/logo/turtle.js
+++ b/logo/turtle.js
@@ -241,7 +241,7 @@ $classObj.create = function(logo, sys) {
     function primitiveSetfloodcolor(color) {
         logo.type.validateInputRGB(color);
         _floodColor = logo.type.isPaletteIndex(color) ? color : logo.type.makeLogoList(logo.type.getRGB(color));
-        logo.ext.canvas.sendCmd("fillcolor",  logo.type.getRGB(_floodColor));
+        logo.ext.canvas.sendCmd("fillcolor", logo.type.getRGB(_floodColor));
     }
     turtle.setfloodcolor = primitiveSetfloodcolor;
 

--- a/logo/ux.js
+++ b/logo/ux.js
@@ -164,7 +164,7 @@ editor.setOptions({
 });
 
 function saveEditorContent() {
-    writeLogoStorage("logoSrc",  editor.getValue());
+    writeLogoStorage("logoSrc", editor.getValue());
 }
 
 window.setInterval(saveEditorContent, 10000);

--- a/unittests/primitives/list.txt
+++ b/unittests/primitives/list.txt
@@ -91,3 +91,4 @@ mouse_queries runl execl
 load run exec
 remove run exec
 remove1 runl execl
+time exec

--- a/unittests/primitives/time.lgo
+++ b/unittests/primitives/time.lgo
@@ -1,0 +1,1 @@
+show time

--- a/unittests/primitives/time.out
+++ b/unittests/primitives/time.out
@@ -1,0 +1,1 @@
+[$dateTimeFormat("EEE MMM dd HH:mm:ss yyyy")]


### PR DESCRIPTION
1. Implement primtive TIME.
2. Update test runner to support a built-in macro that expands to current date/time.
3. Remove some redundant spaces.