### PR TITLE
Fix #298:READLIST not handling backslashes and vertical bars.

### DIFF
--- a/logo/lib/comm.js
+++ b/logo/lib/comm.js
@@ -49,7 +49,39 @@ $obj.create = function(logo) {
 
     async function primitiveReadlist() {
         let userInput = await readHelper();
-        return logo.type.makeLogoList(userInput.split(" "));
+        let newList = logo.type.makeLogoList();
+        let backSlash = false;
+        let verticalBar = false;
+        var word = "";
+        for (var i = 0; i < userInput.length; i++) {
+            if (userInput.charAt(i) === "\\" && i + 1 != userInput.length) {
+                backSlash = true;
+            } else if (backSlash === true) {
+                word += userInput.charAt(i);
+                backSlash = false;
+            } else if (verticalBar === true) {
+                if (userInput.charAt(i) === "|") {
+                    verticalBar = false;
+                } else {
+                    word += userInput.charAt(i);
+                }
+            } else {
+                if (userInput.charAt(i) === " ") {
+                    newList.push(word);
+                    word = "";
+                } else if (userInput.charAt(i) === "|") {
+                    verticalBar = true;
+                } else {
+                    word = word + userInput.charAt(i);
+                }
+            }
+        }
+
+        if (word != "") {
+            newList.push(word);
+        }
+
+        return newList;
     }
 
     async function readHelper() {

--- a/unittests/primitives/readlist.in
+++ b/unittests/primitives/readlist.in
@@ -1,2 +1,3 @@
 Hello World!
 Hello World!
+A\ A B |A A| A

--- a/unittests/primitives/readlist.lgo
+++ b/unittests/primitives/readlist.lgo
@@ -6,4 +6,4 @@ show item 1 :userInput
 show item 2 :userInput
 make "userInput2 readlist
 pr count :userInput2
-for [a 1 4] [show item a :userInput2]
+for [a 1 4] [show item :a :userInput2]

--- a/unittests/primitives/readlist.lgo
+++ b/unittests/primitives/readlist.lgo
@@ -4,3 +4,6 @@ show :userInput = rl
 pr count :userInput
 show item 1 :userInput
 show item 2 :userInput
+make "userInput2 readlist
+pr count :userInput2
+for [a 1 4] [show item a :userInput2]

--- a/unittests/primitives/readlist.out
+++ b/unittests/primitives/readlist.out
@@ -3,3 +3,8 @@ true
 2
 Hello
 World!
+4
+A A
+B
+A A
+A


### PR DESCRIPTION
READLIST now is handling backslashes and vertical bars.

READLIST processes backslashes and vertical bars in the read stream; the output list will not contain these characters but they will have had their usual effect.