### PR TITLE
Refactor:Clean up runtime apply name procedure etc.

### DIFF
--- a/logo/interpreter.js
+++ b/logo/interpreter.js
@@ -212,7 +212,7 @@ $obj.create = function(logo, sys) {
             evxContext.retVal = logo.type.getVarValue(logo.env.extractVarName(curToken), curSrcmap);
         } else if (logo.type.isLogoSlot(curToken)) {
             evxContext.proc = "?";
-            evxContext.retVal = logo.env.callJsProc("?", curSrcmap, logo.env.extractSlotNum(curToken));
+            evxContext.retVal = logo.env.callProc("?", curSrcmap, logo.env.extractSlotNum(curToken));
         } else {
             evxContext.proc = curToken;
             await evxCallProc(evxContext, curToken, curSrcmap, isInParen);
@@ -243,7 +243,7 @@ $obj.create = function(logo, sys) {
     }
 
     async function evxCallProcDefault(...callParams) {
-        let procName = logo.env.getPrimitiveName();
+        let procName = logo.env.getProcName();
         await evxProcCallOptionalRestParam(logo.env.getProcParsedFormal(procName), callParams);
         return await evxProcBody(logo.env.getUserProcMetadata(procName));
     }

--- a/logo/lib/al.js
+++ b/logo/lib/al.js
@@ -12,8 +12,6 @@ var $obj = {};
 $obj.create = function(logo, sys) {
     const al = {};
 
-    const PROC_ATTRIBUTE = logo.constants.PROC_ATTRIBUTE;
-
     const methods = {
 
         // unary minus operator in ambiguous context

--- a/logo/type.js
+++ b/logo/type.js
@@ -651,14 +651,14 @@ $obj.create = function(logo, sys) {
     function ifTrueThenThrow(predicate, exception, value) {
         if (predicate) {
             throw exception.withParam(
-                [logo.env.getPrimitiveName(), logo.type.toString(value, true)],
+                [logo.env.getProcName(), logo.type.toString(value, true)],
                 logo.env.getProcSrcmap());
         }
     }
     type.ifTrueThenThrow = ifTrueThenThrow;
 
     function checkMinInputCount(value) {
-        ifTrueThenThrow(!(value >= logo.env.getProcParsedFormal(logo.env.getPrimitiveName()).minInputCount),
+        ifTrueThenThrow(!(value >= logo.env.getProcParsedFormal(logo.env.getProcName()).minInputCount),
             "NOT_ENOUGH_INPUTS", value);
     }
     type.checkMinInputCount = checkMinInputCount;


### PR DESCRIPTION
1. Merge codepaths for primitives and user procedures.
2. Use `quoteToken()` in codegen.
3. Rename env utils for procedures.