### PR TITLE
Implement PLIST(#353);add support for boolean/numeric plist & prop names.

### DIFF
--- a/logo/env.js
+++ b/logo/env.js
@@ -123,6 +123,8 @@ $obj.create = function(logo, sys, ext) {
     env.getGenJs = getGenJs;
 
     function setProplistPropertyValue(plistName, propName, val) {
+        plistName = logo.type.wordToString(plistName).toLowerCase();
+        propName = logo.type.wordToString(propName);
         if (!(plistName in _globalProplist)) {
             _globalProplist[plistName] = {};
         }
@@ -132,20 +134,33 @@ $obj.create = function(logo, sys, ext) {
     env.setProplistPropertyValue = setProplistPropertyValue;
 
     function getProplistPropertyValue(plistName, propName) {
+        plistName = logo.type.wordToString(plistName).toLowerCase();
+        propName = logo.type.wordToString(propName);
         return (plistName in _globalProplist) && (propName in _globalProplist[plistName]) ?
             _globalProplist[plistName][propName] : logo.type.EMPTY_LIST;
     }
     env.getProplistPropertyValue = getProplistPropertyValue;
 
     function unsetProplistPropertyValue(plistName, propName) {
-        if (!(plistName in _globalProplist)) {
-            _globalProplist[plistName] = {};
-            return;
+        plistName = logo.type.wordToString(plistName).toLowerCase();
+        propName = logo.type.wordToString(propName);
+        if (plistName in _globalProplist) {
+            delete _globalProplist[plistName][propName];
         }
-
-        _globalProplist[plistName][propName] = logo.type.EMPTY_LIST;
     }
     env.unsetProplistPropertyValue = unsetProplistPropertyValue;
+
+    function proplistToList(plistName) {
+        plistName = logo.type.wordToString(plistName).toLowerCase();
+        if (plistName in _globalProplist) {
+            return logo.type.makeLogoList(Object.keys(_globalProplist[plistName])
+                .sort()
+                .map((k) => [k, _globalProplist[plistName][k]]).flat());
+        }
+
+        return logo.type.EMPTY_LIST;
+    }
+    env.proplistToList = proplistToList;
 
     function callProc(name, srcmap, ...args) {
         setProcName(name);

--- a/logo/lib/ws.js
+++ b/logo/lib/ws.js
@@ -41,6 +41,8 @@ $obj.create = function(logo) {
 
         "remprop": primitiveRemprop,
 
+        "plist": primitivePlist,
+
         "load": primitiveLoad,
 
         "help": primitiveHelp,
@@ -120,6 +122,11 @@ $obj.create = function(logo) {
         logo.type.validateInputWord(plist);
         logo.type.validateInputWord(propName);
         return logo.env.unsetProplistPropertyValue(plist, propName);
+    }
+
+    function primitivePlist(plist) {
+        logo.type.validateInputWord(plist);
+        return logo.env.proplistToList(plist);
     }
 
     function primitiveMake(varname, val) {

--- a/unittests/primitives/prop.lgo
+++ b/unittests/primitives/prop.lgo
@@ -1,5 +1,42 @@
-show gprop "propList1 "key
-pprop "propList1 "key "value
-show gprop "propList1 "key
-remprop "propList1 "key
-show gprop "propList1 "key
+pr [Test 1 - GPROP, PPROP, REMPROP]
+show gprop "propList1 "key ; []
+pprop "PropList1 "key "value
+show gprop "propList1 "key ; value
+show gprop "PropList1 "key ; value
+remprop "PROPLIST1 "key
+show gprop "propList1 "key ; []
+show gprop "PROPLIST1 "key ; []
+
+pr [\nTest 2 - Non-existing property lists and keys]
+remprop "propList1 "nonExistingKey ; no error
+remprop "propList2 "nonExistingKey ; no error
+
+pr [\nTest 3 - Booleans and numbers as property list names and keys]
+show gprop (1 > 0) 100 ; []
+pprop (2 > 1) (5+95) "foo
+pprop "true "abc "xyz
+pprop -2 (-2 > -1) "bar
+pprop -2 "xyz "abc
+show gprop "true 100 ; foo
+show gprop -2 "false ; bar
+show plist "TRUE ; [100 foo abc xyz]
+show plist "-2 ; [false bar xyz abc]
+remprop (7 > 6) (50 * 2)
+remprop 1-3 (not "true)
+show gprop (not 1 < 0) (110 - 1) ; []
+show gprop 100-102 "fALse ; []
+show plist (word "t "RUE) ; [abc xyz]
+show plist (word "- 3-1) ; [xyz abc]
+
+pr [\nTest 4 - PLIST]
+pprop "abc "def 100
+show plist "abc ; [def 100]
+pprop "abc "ghi 200
+show plist "abc ; [def 100 ghi 200]
+pprop "abc "jkl []
+show plist "abc ; [def 100 ghi 200 jkl []]
+show gprop "abc "ghi ; 200
+show gprop "abc "jkl ; []
+show gprop "abc "def ; 100
+remprop "abc "def
+show plist "abc ; [ghi 200 jkl []]

--- a/unittests/primitives/prop.out
+++ b/unittests/primitives/prop.out
@@ -1,3 +1,28 @@
+Test 1 - GPROP, PPROP, REMPROP
 []
 value
+value
 []
+[]
+
+Test 2 - Non-existing property lists and keys
+
+Test 3 - Booleans and numbers as property list names and keys
+[]
+foo
+bar
+[100 foo abc xyz]
+[false bar xyz abc]
+[]
+[]
+[abc xyz]
+[xyz abc]
+
+Test 4 - PLIST
+[def 100]
+[def 100 ghi 200]
+[def 100 ghi 200 jkl []]
+200
+[]
+100
+[ghi 200 jkl []]

--- a/unittests/primitives/prop_err.err
+++ b/unittests/primitives/prop_err.err
@@ -22,3 +22,7 @@ remprop doesn't like [] as input
     at 13,1
 remprop doesn't like {} as input
     at 14,1
+plist doesn't like [] as input
+    at 16,1
+plist doesn't like {} as input
+    at 17,1

--- a/unittests/primitives/prop_err.lgo
+++ b/unittests/primitives/prop_err.lgo
@@ -12,3 +12,6 @@ remprop [] "key
 remprop {} "key
 remprop "list []
 remprop "list {}
+
+plist []
+plist {}


### PR DESCRIPTION
PLIST plistname

outputs a list whose odd-numbered members are the names, and
whose even-numbered members are the values, of the properties
in the property list named "plistname". The output is a copy
of the actual property list; changing properties later will not
magically change a list output earlier by PLIST.