### PR TITLE
Refactor:make property list a native data type.

### DIFF
--- a/logo/env.js
+++ b/logo/env.js
@@ -122,43 +122,40 @@ $obj.create = function(logo, sys, ext) {
     }
     env.getGenJs = getGenJs;
 
+    function existsGlobalPlist(plistName) {
+        return plistName in _globalProplist;
+    }
+
     function setProplistPropertyValue(plistName, propName, val) {
-        plistName = logo.type.wordToString(plistName).toLowerCase();
+        plistName = logo.type.wordToStringCaseInsensitive(plistName);
         propName = logo.type.wordToString(propName);
-        if (!(plistName in _globalProplist)) {
-            _globalProplist[plistName] = {};
+        if (!existsGlobalPlist(plistName)) {
+            _globalProplist[plistName] = logo.type.makePlist();
         }
 
-        _globalProplist[plistName][propName] = val;
+        logo.type.plistSet(_globalProplist[plistName], propName, val);
     }
     env.setProplistPropertyValue = setProplistPropertyValue;
 
     function getProplistPropertyValue(plistName, propName) {
-        plistName = logo.type.wordToString(plistName).toLowerCase();
+        plistName = logo.type.wordToStringCaseInsensitive(plistName);
         propName = logo.type.wordToString(propName);
-        return (plistName in _globalProplist) && (propName in _globalProplist[plistName]) ?
-            _globalProplist[plistName][propName] : logo.type.EMPTY_LIST;
+        return (existsGlobalPlist(plistName)) ? logo.type.plistGet(_globalProplist[plistName], propName) : logo.type.EMPTY_LIST;
     }
     env.getProplistPropertyValue = getProplistPropertyValue;
 
     function unsetProplistPropertyValue(plistName, propName) {
-        plistName = logo.type.wordToString(plistName).toLowerCase();
+        plistName = logo.type.wordToStringCaseInsensitive(plistName);
         propName = logo.type.wordToString(propName);
-        if (plistName in _globalProplist) {
-            delete _globalProplist[plistName][propName];
+        if (existsGlobalPlist(plistName)) {
+            logo.type.plistUnset(_globalProplist[plistName], propName);
         }
     }
     env.unsetProplistPropertyValue = unsetProplistPropertyValue;
 
     function proplistToList(plistName) {
-        plistName = logo.type.wordToString(plistName).toLowerCase();
-        if (plistName in _globalProplist) {
-            return logo.type.makeLogoList(Object.keys(_globalProplist[plistName])
-                .sort()
-                .map((k) => [k, _globalProplist[plistName][k]]).flat());
-        }
-
-        return logo.type.EMPTY_LIST;
+        plistName = logo.type.wordToStringCaseInsensitive(plistName);
+        return (existsGlobalPlist(plistName)) ? logo.type.plistToList(_globalProplist[plistName]) : logo.type.EMPTY_LIST;
     }
     env.proplistToList = proplistToList;
 

--- a/logo/type.js
+++ b/logo/type.js
@@ -833,6 +833,36 @@ $obj.create = function(logo, sys) {
     }
     type.arrayFindItem = arrayFindItem;
 
+    function makePlist() {
+        return {};
+    }
+    type.makePlist = makePlist;
+
+    function plistSet(plist, propName, val) {
+        plist[propName] = val;
+    }
+    type.plistSet = plistSet;
+
+    function plistUnset(plist, propName) {
+        if (propName in plist) {
+            delete plist[propName];
+        }
+    }
+    type.plistUnset = plistUnset;
+
+    function plistGet(plist, propName) {
+        return (propName in plist) ? plist[propName] : EMPTY_LIST;
+    }
+    type.plistGet = plistGet;
+
+    function plistToList(plist) {
+        return makeLogoList(Object.keys(plist)
+            .sort()
+            .map((k) => [k, plist[k]])
+            .flat());
+    }
+    type.plistToList = plistToList;
+
     function wordToString(word) {
         switch (typeof word) {
         case "string": return word;
@@ -842,6 +872,11 @@ $obj.create = function(logo, sys) {
         }
     }
     type.wordToString = wordToString;
+
+    function wordToStringCaseInsensitive(word) {
+        return wordToString(word).toLowerCase();
+    }
+    type.wordToStringCaseInsensitive = wordToStringCaseInsensitive;
 
     function isLogoNumber(s) {
         return (typeof s === "number") || (typeof s === "string" && !isNaN(Number(s)));


### PR DESCRIPTION
To prepare for passing property lists by reference (not just by name).