### PR TITLE
Implement LISTTOPLIST, PLISTP, PLIST? and scoped property list.

### DIFF
--- a/logo/config.js
+++ b/logo/config.js
@@ -18,6 +18,7 @@ $obj.create = function create(sys, origConfigMap = undefined) {
         deepCallStack: false,
         pclogo: false,
         clougo: true,
+        scopedPlist: true,
         trace: true
     } : Object.assign({}, origConfigMap);
 

--- a/logo/env.js
+++ b/logo/env.js
@@ -69,7 +69,7 @@ $obj.create = function(logo, sys, ext) {
 
     let _logoMode = LogoMode.BATCH;
     let _globalScope, _envState, _runTime, _userInput, _resolveUserInput;
-    let _globalProplist;
+    let _globalPlists;
     let _asyncFunctionCall;
     let _genJs;
     let $primitiveName, $primitiveSrcmap;
@@ -123,41 +123,38 @@ $obj.create = function(logo, sys, ext) {
     env.getGenJs = getGenJs;
 
     function existsGlobalPlist(plistName) {
-        return plistName in _globalProplist;
+        return plistName in _globalPlists;
     }
 
-    function setProplistPropertyValue(plistName, propName, val) {
+    function setPlistPropertyValue(plistName, propName, val) {
         plistName = logo.type.wordToStringCaseInsensitive(plistName);
-        propName = logo.type.wordToString(propName);
         if (!existsGlobalPlist(plistName)) {
-            _globalProplist[plistName] = logo.type.makePlist();
+            _globalPlists[plistName] = logo.type.makePlist();
         }
 
-        logo.type.plistSet(_globalProplist[plistName], propName, val);
+        logo.type.plistSet(_globalPlists[plistName], propName, val);
     }
-    env.setProplistPropertyValue = setProplistPropertyValue;
+    env.setPlistPropertyValue = setPlistPropertyValue;
 
-    function getProplistPropertyValue(plistName, propName) {
+    function getPlistPropertyValue(plistName, propName) {
         plistName = logo.type.wordToStringCaseInsensitive(plistName);
-        propName = logo.type.wordToString(propName);
-        return (existsGlobalPlist(plistName)) ? logo.type.plistGet(_globalProplist[plistName], propName) : logo.type.EMPTY_LIST;
+        return (existsGlobalPlist(plistName)) ? logo.type.plistGet(_globalPlists[plistName], propName) : logo.type.EMPTY_LIST;
     }
-    env.getProplistPropertyValue = getProplistPropertyValue;
+    env.getPlistPropertyValue = getPlistPropertyValue;
 
-    function unsetProplistPropertyValue(plistName, propName) {
+    function unsetPlistPropertyValue(plistName, propName) {
         plistName = logo.type.wordToStringCaseInsensitive(plistName);
-        propName = logo.type.wordToString(propName);
         if (existsGlobalPlist(plistName)) {
-            logo.type.plistUnset(_globalProplist[plistName], propName);
+            logo.type.plistUnset(_globalPlists[plistName], propName);
         }
     }
-    env.unsetProplistPropertyValue = unsetProplistPropertyValue;
+    env.unsetPlistPropertyValue = unsetPlistPropertyValue;
 
-    function proplistToList(plistName) {
+    function plistToList(plistName) {
         plistName = logo.type.wordToStringCaseInsensitive(plistName);
-        return (existsGlobalPlist(plistName)) ? logo.type.plistToList(_globalProplist[plistName]) : logo.type.EMPTY_LIST;
+        return (existsGlobalPlist(plistName)) ? logo.type.plistToList(_globalPlists[plistName]) : logo.type.EMPTY_LIST;
     }
-    env.proplistToList = proplistToList;
+    env.plistToList = plistToList;
 
     function callProc(name, srcmap, ...args) {
         setProcName(name);
@@ -389,7 +386,7 @@ $obj.create = function(logo, sys, ext) {
         _globalScope = {"_global": 1 };
         _procJsFunc = Object.create(_primitiveJsFunc);
         _procMetadata = Object.create(_primitiveMetadata);
-        _globalProplist = {};
+        _globalPlists = {};
 
         env._scopeStack = [_globalScope];
         env._userBlock = new WeakMap();

--- a/logo/lib/ds.js
+++ b/logo/lib/ds.js
@@ -32,6 +32,8 @@ $obj.create = function(logo) {
 
         "arraytolist": primitiveArrayToList,
 
+        "listtoplist": primitiveListtoplist,
+
         "reverse": primitiveReverse,
 
         "first": primitiveFirst,
@@ -71,6 +73,9 @@ $obj.create = function(logo) {
 
         "memberp": primitiveMemberp,
         "member?": primitiveMemberp,
+
+        "plistp": primitivePlistp,
+        "plist?": primitivePlistp,
 
         "count": primitiveCount,
 
@@ -114,6 +119,11 @@ $obj.create = function(logo) {
     function primitiveArrayToList(value) {
         logo.type.validateInputArray(value);
         return logo.type.arrayToList(value);
+    }
+
+    function primitiveListtoplist(value) {
+        logo.type.validateInputList(value);
+        return logo.type.listToPlist(value);
     }
 
     function primitiveAscii(value) {
@@ -250,6 +260,11 @@ $obj.create = function(logo) {
         logo.type.validateInputArray(group);
         return logo.type.arrayFindItem(candidate, group) !== -1;
     }
+
+    function primitivePlistp(val) {
+        return logo.type.isLogoPlist(val);
+    }
+
     function primitiveButfirst(thing) {
         if (logo.type.isLogoWord(thing)) {
             if (typeof thing === "boolean") {

--- a/logo/lib/ws.js
+++ b/logo/lib/ws.js
@@ -107,26 +107,43 @@ $obj.create = function(logo) {
     }
 
     function primitivePprop(plist, propName, val) {
-        logo.type.validateInputWord(plist);
         logo.type.validateInputWord(propName);
-        logo.env.setProplistPropertyValue(plist, propName, val);
+        if (logo.config.get("scopedPlist") && logo.type.isLogoPlist(plist)) {
+            logo.type.plistSet(plist, propName, val);
+            return;
+        }
+
+        logo.type.validateInputWord(plist);
+        logo.env.setPlistPropertyValue(plist, propName, val);
     }
 
     function primitiveGprop(plist, propName) {
-        logo.type.validateInputWord(plist);
         logo.type.validateInputWord(propName);
-        return logo.env.getProplistPropertyValue(plist, propName);
+        if (logo.config.get("scopedPlist") && logo.type.isLogoPlist(plist)) {
+            return logo.type.plistGet(plist, propName);
+        }
+
+        logo.type.validateInputWord(plist);
+        return logo.env.getPlistPropertyValue(plist, propName);
     }
 
     function primitiveRemprop(plist, propName) {
-        logo.type.validateInputWord(plist);
         logo.type.validateInputWord(propName);
-        return logo.env.unsetProplistPropertyValue(plist, propName);
+        if (logo.config.get("scopedPlist") && logo.type.isLogoPlist(plist)) {
+            return logo.type.plistUnset(plist, propName);
+        }
+
+        logo.type.validateInputWord(plist);
+        return logo.env.unsetPlistPropertyValue(plist, propName);
     }
 
     function primitivePlist(plist) {
+        if (logo.config.get("scopedPlist") && logo.type.isLogoPlist(plist)) {
+            return logo.type.plistToList(plist);
+        }
+
         logo.type.validateInputWord(plist);
-        return logo.env.proplistToList(plist);
+        return logo.env.plistToList(plist);
     }
 
     function primitiveMake(varname, val) {

--- a/unittests/primitives/list.txt
+++ b/unittests/primitives/list.txt
@@ -136,3 +136,4 @@ defmacro_err runl execl
 text_defmacro run exec
 prop run exec
 prop_err runl execl
+prop_var run,+scopedPlist exec,+scopedPlist

--- a/unittests/primitives/prop_var.lgo
+++ b/unittests/primitives/prop_var.lgo
@@ -1,0 +1,28 @@
+to compare :x :y
+output :x = :y
+end
+
+to make_plist :list
+output listtoplist :list
+end
+
+make "a listtoplist [1 2]
+show :a
+pprop :a "xyz 100
+show :a
+show gprop :a "xyz
+remprop :a 1
+show :a
+
+make "b make_plist [xyz 100]
+show :a = :b
+show compare :a :b
+
+show plistp :a
+show plist? :b
+show plist? plist :a
+show plistp plist :b
+
+make "c make_plist [{} [1 2 3]]
+show gprop :c "\{\}
+show listp gprop :c "\{\}

--- a/unittests/primitives/prop_var.out
+++ b/unittests/primitives/prop_var.out
@@ -1,0 +1,12 @@
+[1 2]
+[1 2 xyz 100]
+100
+[xyz 100]
+true
+true
+true
+true
+false
+false
+[1 2 3]
+true


### PR DESCRIPTION
A scoped property list works just like a conventional property list
for PPROP, GPROP, REMPROP, and PLIST, except the scoped property list
is used by reference instead of by name.
Unlike conventional property lists, scoped property lists can be
assigned to variables, passed to inputs, or returned as outputs.